### PR TITLE
[refactor] 과제 템플릿명 명칭 변경 및 템플릿 의존성 제거

### DIFF
--- a/src/main/kotlin/com/barostartbe/domain/assignment/dto/request/AssignmentCreateReq.kt
+++ b/src/main/kotlin/com/barostartbe/domain/assignment/dto/request/AssignmentCreateReq.kt
@@ -26,12 +26,10 @@ data class AssignmentCreateReq(
     @field:NotNull(message = "dueAt는 필수입니다")
     val dueDate: LocalDateTime,
 
-    @Schema(description = "선택한 과제 템플릿 ID(선택 안하면 null)", example = "1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    val templateId: Long? = null,
-
-    @Schema(description = "멘토가 직접 입력한 과제 목표", example = "오답 원인 분석 및 재풀이")
-    @field:Size(max = 1000, message = "goalText는 1000자를 초과할 수 없습니다")
-    val goalText: String? = null,
+    @Schema(description = "선택한 과제 템플릿 이름 (과제 목표)", example = "미적분 오답 정리 템플릿", requiredMode = Schema.RequiredMode.REQUIRED)
+    @field:NotBlank(message = "templateName은 필수입니다")
+    @field:Size(max = 100, message = "templateName은 100자를 초과할 수 없습니다")
+    val templateName: String,
 
     @Schema(description = "과제 내용", example = "미적분 문제집 3단원 1~20번 풀이", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @field:Size(max = 3000, message = "content는 3000자를 초과할 수 없습니다")

--- a/src/main/kotlin/com/barostartbe/domain/assignment/dto/response/AssignmentMenteeDetailRes.kt
+++ b/src/main/kotlin/com/barostartbe/domain/assignment/dto/response/AssignmentMenteeDetailRes.kt
@@ -19,8 +19,8 @@ data class AssignmentMenteeDetailRes(
     @Schema(description = "마감 일시")
     val dueDate: LocalDateTime,
 
-    @Schema(description = "과제 목표")
-    val goal: String?,
+    @Schema(description = "과제 템플릿 이름 (과제 목표)")
+    val templateName: String,
 
     @Schema(description = "과제 내용")
     val content: String?,

--- a/src/main/kotlin/com/barostartbe/domain/assignment/dto/response/AssignmentMenteeListRes.kt
+++ b/src/main/kotlin/com/barostartbe/domain/assignment/dto/response/AssignmentMenteeListRes.kt
@@ -24,8 +24,8 @@ data class AssignmentMenteeListRes(
     @Schema(description = "제출 여부")
     val status: AssignmentStatus,
 
-    @Schema(description = "과제 목표")
-    val goal: String?,
+    @Schema(description = "과제 템플릿명(과제 목표)")
+    val templateName: String,
 
     @Schema(description = "제출 완료 시간 (미제출 시 null)")
     val submittedAt: LocalDateTime?
@@ -38,7 +38,7 @@ data class AssignmentMenteeListRes(
                 title = assignment.title,
                 content = assignment.content,
                 status = assignment.status,
-                goal = assignment.goalText,
+                templateName = assignment.templateName,
                 submittedAt = assignment.submittedAt
             )
     }

--- a/src/main/kotlin/com/barostartbe/domain/assignment/entity/Assignment.kt
+++ b/src/main/kotlin/com/barostartbe/domain/assignment/entity/Assignment.kt
@@ -5,7 +5,6 @@ import com.barostartbe.domain.assignment.entity.enum.AssignmentStatus
 import com.barostartbe.domain.assignment.entity.enum.Subject
 import com.barostartbe.domain.assignment.error.AssignmentFeedbackedException
 import com.barostartbe.domain.assignment.error.AssignmentNotSubmittedException
-import com.barostartbe.domain.assignmenttemplate.entity.AssignmentTemplate
 import com.barostartbe.domain.mentor.entity.Mentor
 import com.barostartbe.domain.mentee.entity.Mentee
 import com.barostartbe.global.common.entity.BaseEntity
@@ -24,12 +23,8 @@ class Assignment(
     @JoinColumn(name = "mentee_id", nullable = false)
     val mentee: Mentee,
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "template_id")
-    val assignmentTemplate: AssignmentTemplate? = null,
-
-    @Column(name = "goal_text", columnDefinition = "TEXT", nullable = false)
-    val goalText: String,
+    @Column(name = "template_name", nullable = false, length = 100)
+    val templateName: String,
 
     @Column(nullable = false, length = 100)
     val title: String,
@@ -108,15 +103,13 @@ class Assignment(
         fun create(
             mentor: Mentor,
             mentee: Mentee,
-            assignmentTemplate: AssignmentTemplate?,
-            goalText: String,
+            templateName: String,
             req: AssignmentCreateReq
         ): Assignment =
             Assignment(
                 mentor = mentor,
                 mentee = mentee,
-                assignmentTemplate = assignmentTemplate,
-                goalText = goalText,
+                templateName =  templateName,
                 title = req.title,
                 subject = req.subject,
                 dueDate = req.dueDate,

--- a/src/main/kotlin/com/barostartbe/domain/assignment/usecase/AssignmentCommandUseCase.kt
+++ b/src/main/kotlin/com/barostartbe/domain/assignment/usecase/AssignmentCommandUseCase.kt
@@ -25,7 +25,6 @@ import java.time.LocalDateTime
 class AssignmentCommandUseCase(
     private val assignmentRepository: AssignmentRepository,
     private val assignmentFileRepository: AssignmentFileRepository,
-    private val assignmentTemplateRepository: AssignmentTemplateRepository,
     private val mentorRepository: MentorRepository,
     private val menteeRepository: MenteeRepository,
     private val mentorMenteeMappingRepository: MentorMenteeMappingRepository,
@@ -46,24 +45,13 @@ class AssignmentCommandUseCase(
             ?: throw ServiceException(ErrorCode.UNMATCHED_PAIR)
 
         // 과제 목표 조회
-        val assignmentTemplate: AssignmentTemplate? =
-            req.templateId?.let {
-                assignmentTemplateRepository.findById(it)
-                    .orElseThrow { ServiceException(ErrorCode.NOT_FOUND) }
-            }
-
-        // 과제 목표 텍스트 결정
-        val goalText: String =
-            assignmentTemplate?.name
-                ?: req.goalText
-                ?: throw ServiceException(ErrorCode.INVALID_REQUEST)
+        val templateName: String = req.templateName
 
         val assignment = assignmentRepository.save(
             Assignment.create(
                 mentor = mentor,
                 mentee = mentee,
-                assignmentTemplate = assignmentTemplate,
-                goalText = goalText,
+                templateName = templateName,
                 req = req
             )
         )

--- a/src/main/kotlin/com/barostartbe/domain/assignment/usecase/AssignmentQueryUseCase.kt
+++ b/src/main/kotlin/com/barostartbe/domain/assignment/usecase/AssignmentQueryUseCase.kt
@@ -4,12 +4,10 @@ import com.barostartbe.domain.assignment.dto.response.AssignmentFileRes
 import com.barostartbe.domain.assignment.dto.response.AssignmentMenteeDetailRes
 import com.barostartbe.domain.assignment.dto.response.AssignmentMenteeListRes
 import com.barostartbe.domain.assignment.entity.enum.AssignmentFileType
-import com.barostartbe.domain.assignment.entity.enum.AssignmentStatus
 import com.barostartbe.domain.assignment.entity.enum.Subject
 import com.barostartbe.domain.assignment.error.AssignmentNotFoundException
 import com.barostartbe.domain.assignment.repository.AssignmentFileRepository
 import com.barostartbe.domain.assignment.repository.AssignmentRepository
-import com.barostartbe.domain.objectstorage.usecase.GetPreAuthenticatedUrl
 import com.barostartbe.global.annotation.QueryUseCase
 import com.barostartbe.global.error.exception.ServiceException
 import com.barostartbe.global.response.type.ErrorCode
@@ -91,7 +89,7 @@ class AssignmentQueryUseCase(
             title = assignment.title,
             subject = assignment.subject,
             dueDate = assignment.dueDate,
-            goal = assignment.goalText,
+            templateName = assignment.templateName,
             content = assignment.content,
             seolStudyContext = assignment.seolStudyContext,
             materials = materials,


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정 (README.md 등)
- [ ] 코드 포맷 변경, 세미콜론 누락 등 (로직 변경 없음)
- [x] 코드 리팩토링 (기능 변화 없이 코드 구조만 개선)
- [ ] 테스트 코드 추가 및 수정
- [ ] 빌드 업무, 패키지 매니저 설정, .gitignore 수정 등
- [ ] 성능 개선
- [ ] CI 설정 파일 수정

---

## ✏️ 작업 내용
AssignmentCreateReq 내 templateId 필드 제거
Assignment 엔티티와 AssignmentTemplate의 연관관계를 끊고 독립적인 도메인으로 분리
goalText 데이터 삭제 및 템플릿명(구 과제목표)로 명확히 정의


---

## 🔗 관련 이슈
- closes #22 