### PR TITLE
test: 피드백 동시성 부하 벤치마크 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,21 @@ kotlin {
     }
 }
 
-tasks.withType<Test> {
-    useJUnitPlatform()
+// 기본 test task — 벤치마크 / 부하 테스트는 외부 MySQL · Redis 컨테이너가 필요하므로 제외
+tasks.named<Test>("test") {
+    useJUnitPlatform {
+        excludeTags("bench")
+    }
+}
+
+// 로컬 부하 / 동시성 측정 전용 task — `docker-compose-bench.yml` 띄운 뒤 실행
+tasks.register<Test>("benchTest") {
+    description = "부하 / 동시성 벤치마크 테스트 (로컬 전용, MySQL · Redis 필요)"
+    group = "verification"
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    useJUnitPlatform {
+        includeTags("bench")
+    }
+    outputs.upToDateWhen { false }
 }

--- a/docker-compose-bench.yml
+++ b/docker-compose-bench.yml
@@ -1,0 +1,31 @@
+version: "3.8"
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: barostart-bench-mysql
+    ports:
+      - "3307:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: barostart_bench
+      TZ: Asia/Seoul
+    command:
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  redis:
+    image: redis:7-alpine
+    container_name: barostart-bench-redis
+    ports:
+      - "6380:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 3s
+      retries: 20

--- a/src/main/kotlin/com/barostartbe/global/config/OciConfig.kt
+++ b/src/main/kotlin/com/barostartbe/global/config/OciConfig.kt
@@ -6,11 +6,14 @@ import com.oracle.bmc.objectstorage.ObjectStorageClient
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import java.io.FileInputStream
 import java.io.InputStream
 import java.util.function.Supplier
 
+// 벤치/통합 테스트에서는 OCI 인증을 우회하기 위해 bench 프로필에서 비활성화
 @Configuration
+@Profile("!bench")
 class OciConfig(
     @Value("\${oci.tenant-id}")
     private val tenantId: String,

--- a/src/test/kotlin/com/barostartbe/bench/BenchTestConfig.kt
+++ b/src/test/kotlin/com/barostartbe/bench/BenchTestConfig.kt
@@ -1,0 +1,14 @@
+package com.barostartbe.bench
+
+import com.oracle.bmc.objectstorage.ObjectStorage
+import io.mockk.mockk
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+
+// bench 프로필에서 OciConfig 가 비활성화되므로, ObjectStorage Bean 을 mock 으로 대체
+@TestConfiguration
+class BenchTestConfig {
+
+    @Bean
+    fun objectStorage(): ObjectStorage = mockk(relaxed = true)
+}

--- a/src/test/kotlin/com/barostartbe/bench/FeedbackConcurrencyBench.kt
+++ b/src/test/kotlin/com/barostartbe/bench/FeedbackConcurrencyBench.kt
@@ -16,6 +16,7 @@ import com.barostartbe.domain.mentor.repository.MentorRepository
 import com.barostartbe.domain.notification.repository.NotificationRepository
 import com.barostartbe.global.error.exception.ServiceException
 import com.barostartbe.global.response.type.ErrorCode
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -30,6 +31,8 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 // 피드백 생성에서 race 차단 / 비즈니스 로직 차단 동작을 두 시나리오로 측정
+// CI 에서는 MySQL · Redis 컨테이너가 없어 제외, 로컬에서 `./gradlew benchTest` 로만 실행
+@Tag("bench")
 @SpringBootTest
 @ActiveProfiles("bench")
 @Import(BenchTestConfig::class)

--- a/src/test/kotlin/com/barostartbe/bench/FeedbackConcurrencyBench.kt
+++ b/src/test/kotlin/com/barostartbe/bench/FeedbackConcurrencyBench.kt
@@ -1,0 +1,222 @@
+package com.barostartbe.bench
+
+import com.barostartbe.domain.assignment.entity.Assignment
+import com.barostartbe.domain.assignment.entity.enums.AssignmentStatus
+import com.barostartbe.domain.assignment.entity.enums.Subject
+import com.barostartbe.domain.assignment.repository.AssignmentRepository
+import com.barostartbe.domain.feedback.dto.request.FeedbackCreateReq
+import com.barostartbe.domain.feedback.repository.FeedbackRepository
+import com.barostartbe.domain.feedback.usecase.FeedbackCreateUseCase
+import com.barostartbe.domain.mentee.entity.Grade
+import com.barostartbe.domain.mentee.entity.Mentee
+import com.barostartbe.domain.mentee.entity.School
+import com.barostartbe.domain.mentee.repository.MenteeRepository
+import com.barostartbe.domain.mentor.entity.Mentor
+import com.barostartbe.domain.mentor.repository.MentorRepository
+import com.barostartbe.domain.notification.repository.NotificationRepository
+import com.barostartbe.global.error.exception.ServiceException
+import com.barostartbe.global.response.type.ErrorCode
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.test.context.ActiveProfiles
+import java.time.LocalDateTime
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+// 피드백 생성에서 race 차단 / 비즈니스 로직 차단 동작을 두 시나리오로 측정
+@SpringBootTest
+@ActiveProfiles("bench")
+@Import(BenchTestConfig::class)
+class FeedbackConcurrencyBench @Autowired constructor(
+    private val feedbackCreateUseCase: FeedbackCreateUseCase,
+    private val mentorRepository: MentorRepository,
+    private val menteeRepository: MenteeRepository,
+    private val assignmentRepository: AssignmentRepository,
+    private val feedbackRepository: FeedbackRepository,
+    private val notificationRepository: NotificationRepository,
+) {
+
+    private val totalRequests = 100
+
+    private fun freshAssignmentFixture(suffix: String): Triple<Long, Long, FeedbackCreateReq> {
+        val mentor = mentorRepository.save(
+            Mentor(
+                loginId = "bench-mentor-$suffix",
+                password = "x",
+                name = "벤치멘토",
+                nickname = "bench-mentor-$suffix",
+                university = "TestU",
+            )
+        )
+        val mentee = menteeRepository.save(
+            Mentee(
+                loginId = "bench-mentee-$suffix",
+                password = "x",
+                name = "벤치멘티",
+                nickname = "bench-mentee-$suffix",
+                grade = Grade.SECOND,
+                school = School.NORMAL,
+                hopeMajor = "CS",
+            )
+        )
+        val assignment = assignmentRepository.save(
+            Assignment(
+                mentor = mentor,
+                mentee = mentee,
+                templateName = "벤치 템플릿",
+                title = "벤치 과제",
+                subject = Subject.KOREAN,
+                dueDate = LocalDateTime.now().plusDays(1),
+                content = "벤치용 과제 내용",
+            ).also {
+                it.status = AssignmentStatus.SUBMITTED
+                it.startTime = LocalDateTime.now().minusHours(2)
+                it.endTime = LocalDateTime.now().minusHours(1)
+                it.submittedAt = LocalDateTime.now()
+            }
+        )
+        return Triple(mentor.id!!, assignment.id!!, FeedbackCreateReq(content = "벤치 피드백", summary = null))
+    }
+
+    private data class BenchResult(
+        val successes: Int,
+        val alreadyFeedbacked: Int,
+        val notSubmitted: Int,
+        val dataIntegrityViolation: Int,
+        val others: Int,
+        val p50Ms: Long,
+        val p95Ms: Long,
+        val minMs: Long,
+        val maxMs: Long,
+    )
+
+    private fun printResult(label: String, r: BenchResult) {
+        println()
+        println("============================================================")
+        println("📊 $label (n=$totalRequests)")
+        println("============================================================")
+        println("DB INSERT 성공                : ${r.successes}")
+        println("ASSIGNMENT_ALREADY_FEEDBACKED : ${r.alreadyFeedbacked}")
+        println("ASSIGNMENT_NOT_SUBMITTED      : ${r.notSubmitted}")
+        println("DataIntegrityViolation 누출   : ${r.dataIntegrityViolation}")
+        println("Other exceptions (Deadlock 등): ${r.others}")
+        println("응답시간 P50                  : ${r.p50Ms} ms")
+        println("응답시간 P95                  : ${r.p95Ms} ms")
+        println("응답시간 min / max            : ${r.minMs} / ${r.maxMs} ms")
+        println("============================================================")
+    }
+
+    @Test
+    fun `시나리오 A - 순차 호출 100건 (일반 사용 패턴)`() {
+        val (mentorId, assignmentId, req) = freshAssignmentFixture("seq")
+
+        val successes = AtomicInteger()
+        val alreadyFeedbacked = AtomicInteger()
+        val notSubmitted = AtomicInteger()
+        val div = AtomicInteger()
+        val others = AtomicInteger()
+        val durationsNs = mutableListOf<Long>()
+
+        repeat(totalRequests) {
+            val t0 = System.nanoTime()
+            try {
+                feedbackCreateUseCase.create(mentorId, assignmentId, req)
+                successes.incrementAndGet()
+            } catch (e: ServiceException) {
+                when (e.errorCode) {
+                    ErrorCode.ASSIGNMENT_ALREADY_FEEDBACKED -> alreadyFeedbacked.incrementAndGet()
+                    ErrorCode.ASSIGNMENT_NOT_SUBMITTED -> notSubmitted.incrementAndGet()
+                    else -> others.incrementAndGet()
+                }
+            } catch (e: DataIntegrityViolationException) {
+                div.incrementAndGet()
+            } catch (e: Exception) {
+                others.incrementAndGet()
+            } finally {
+                durationsNs.add(System.nanoTime() - t0)
+            }
+        }
+
+        val sortedMs = durationsNs.sorted().map { it / 1_000_000 }
+        val r = BenchResult(
+            successes = successes.get(),
+            alreadyFeedbacked = alreadyFeedbacked.get(),
+            notSubmitted = notSubmitted.get(),
+            dataIntegrityViolation = div.get(),
+            others = others.get(),
+            p50Ms = sortedMs[sortedMs.size / 2],
+            p95Ms = sortedMs[(sortedMs.size * 95 / 100).coerceAtMost(sortedMs.size - 1)],
+            minMs = sortedMs.first(),
+            maxMs = sortedMs.last(),
+        )
+        printResult("시나리오 A — 순차 호출", r)
+        println("DB 내 피드백 총 건수: ${feedbackRepository.count()}")
+        println("DB 내 알림 총 건수  : ${notificationRepository.count()}")
+    }
+
+    @Test
+    fun `시나리오 B - 완전 동시 100건 요청 (극단적 race)`() {
+        val (mentorId, assignmentId, req) = freshAssignmentFixture("race")
+
+        val executor = Executors.newFixedThreadPool(totalRequests)
+        val startLatch = CountDownLatch(1)
+        val doneLatch = CountDownLatch(totalRequests)
+
+        val successes = AtomicInteger()
+        val alreadyFeedbacked = AtomicInteger()
+        val notSubmitted = AtomicInteger()
+        val div = AtomicInteger()
+        val others = AtomicInteger()
+        val durationsNs = ConcurrentLinkedQueue<Long>()
+
+        repeat(totalRequests) {
+            executor.submit {
+                runCatching { startLatch.await() }
+                val t0 = System.nanoTime()
+                try {
+                    feedbackCreateUseCase.create(mentorId, assignmentId, req)
+                    successes.incrementAndGet()
+                } catch (e: ServiceException) {
+                    when (e.errorCode) {
+                        ErrorCode.ASSIGNMENT_ALREADY_FEEDBACKED -> alreadyFeedbacked.incrementAndGet()
+                        ErrorCode.ASSIGNMENT_NOT_SUBMITTED -> notSubmitted.incrementAndGet()
+                        else -> others.incrementAndGet()
+                    }
+                } catch (e: DataIntegrityViolationException) {
+                    div.incrementAndGet()
+                } catch (e: Exception) {
+                    others.incrementAndGet()
+                } finally {
+                    durationsNs.add(System.nanoTime() - t0)
+                    doneLatch.countDown()
+                }
+            }
+        }
+
+        startLatch.countDown()
+        check(doneLatch.await(60, TimeUnit.SECONDS)) { "타임아웃" }
+        executor.shutdown()
+
+        val sortedMs = durationsNs.toList().sorted().map { it / 1_000_000 }
+        val r = BenchResult(
+            successes = successes.get(),
+            alreadyFeedbacked = alreadyFeedbacked.get(),
+            notSubmitted = notSubmitted.get(),
+            dataIntegrityViolation = div.get(),
+            others = others.get(),
+            p50Ms = sortedMs[sortedMs.size / 2],
+            p95Ms = sortedMs[(sortedMs.size * 95 / 100).coerceAtMost(sortedMs.size - 1)],
+            minMs = sortedMs.first(),
+            maxMs = sortedMs.last(),
+        )
+        printResult("시나리오 B — 완전 동시 호출", r)
+        println("DB 내 피드백 총 건수: ${feedbackRepository.count()}")
+        println("DB 내 알림 총 건수  : ${notificationRepository.count()}")
+    }
+}

--- a/src/test/resources/application-bench.yaml
+++ b/src/test/resources/application-bench.yaml
@@ -1,0 +1,52 @@
+spring:
+  datasource:
+    username: root
+    url: jdbc:mysql://localhost:3307/barostart_bench?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    password: root
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  sql:
+    init:
+      mode: never
+
+  data:
+    redis:
+      host: localhost
+      port: 6380
+      ssl:
+        enabled: false
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    defer-datasource-initialization: false
+    properties:
+      hibernate:
+        format_sql: false
+        use_sql_comments: false
+    show_sql: false
+    open-in-view: false
+
+jwt:
+  secret: dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3Q=
+  issuer: bench
+  token:
+    expire: 600000
+  refresh:
+    expire: 3600000
+
+oci:
+  tenant-id: ocid1.tenancy.oc1..bench
+  user-id: ocid1.user.oc1..bench
+  fingerprint: 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+  private-key-path: /tmp/bench-fake-oci-key.pem
+  region: ap-seoul-1
+  bucket:
+    name: bench
+    namespace: bench
+
+app:
+  server:
+    url: http://localhost:8080
+  service:
+    url: http://localhost:3000


### PR DESCRIPTION
## 개요

`FeedbackCreateUseCase` 의 race / 비즈니스 로직 차단 동작을 두 시나리오로 측정하는 통합 벤치마크를 추가합니다.

## 변경

- `src/test/kotlin/com/barostartbe/bench/FeedbackConcurrencyBench.kt` — 100 건 순차 / 완전 동시 호출 시나리오
- `src/test/kotlin/com/barostartbe/bench/BenchTestConfig.kt` — bench profile 에서 `ObjectStorage` mock Bean 등록
- `src/test/resources/application-bench.yaml` — 벤치 전용 DB / Redis / 더미 OCI 설정
- `docker-compose-bench.yml` — 격리된 MySQL (3307) + Redis (6380) 컨테이너
- `src/main/kotlin/com/barostartbe/global/config/OciConfig.kt` — `@Profile("!bench")` 로 벤치 환경에서 OCI 인증 우회 (1 줄 수정)

## 실행

```bash
docker compose -f docker-compose-bench.yml up -d
./gradlew test --tests 'com.barostartbe.bench.FeedbackConcurrencyBench' --rerun-tasks
```

## 측정 결과 (Spring Boot 4.0 / MySQL 8 / HikariCP 10 connection)

| 지표 | 시나리오 A — 순차 100 건 | 시나리오 B — 완전 동시 100 건 |
|---|---|---|
| DB INSERT 성공 | **1 건** | **1 건** |
| `ASSIGNMENT_NOT_SUBMITTED` 응답 | 99 건 | 90 건 |
| `DataIntegrityViolation` 누출 | 0 건 | 0 건 |
| InnoDB Deadlock (트랜잭션 자동 롤백) | 0 건 | 9 건 |
| 응답시간 P50 | 1 ms | 132 ms |
| 응답시간 P95 | 2 ms | 155 ms |
| DB 내 피드백 / 알림 최종 | 1 / 1 | 1 / 1 |

- 시나리오 A: 첫 호출이 `assignment.status` 를 `FEEDBACKED` 로 전이 → 후속 99 건은 단계 3 (상태 검증) 에서 차단
- 시나리오 B: race window 안의 9 건만 InnoDB Deadlock 으로 롤백, DB 무결성 1 건 유지

상세 의사결정 / 결과는 [위키 — 피드백 동시성 제어와 상태 전이](https://github.com/BaroStart/Backend/wiki/피드백-동시성-제어와-상태-전이) 페이지를 참고해 주세요.